### PR TITLE
fix: correct target in build instructions for WASM binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ cargo install wasm-opt
 To build the WASM binary, run:
 
 ```bash
-wasm-pack build --target web
+wasm-pack build --target bundler
 ```
 
 This will generate a `pkg` directory containing the WASM binary and a JavaScript wrapper. You can use it as a npm package. The `--target web` specifies that the WASM binary is for web usage (inside browser), other options like `nodejs` or `deno` also exist if you want to use it in other environments.


### PR DESCRIPTION
## Which issue does is this PR related to?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123. 

-->

- This PR is related to https://github.com/datafusion-contrib/datafusion-wasm-playground/issues/4

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Basically, the [datafusion-wasm package](https://www.npmjs.com/package/datafusion-wasm?activeTab=readme) in is not built correctly for datafusion-playground, we need to rebuild the package with `wasm-pack build --target bundler` and then republish the package to resolve [this issue](https://github.com/datafusion-contrib/datafusion-wasm-playground/issues/4).

I dug into the wasm build process and figured out that the problem comes from using different wasm-pack build targets for different purposes. Basically, `wasm-pack build --target bundler` is meant for web apps built with bundlers like Vite (**datafusion-playground is built with Vite**) or Webpack, while `wasm-pack build --target web` is for when you want to directly load a wasm package as a native ES module (using `<script type="module"></script>`). 

The deeper reason is the `.js` file loading mechanism built from this two targets are different, but we probably don't need to get into the implementation details to fix this issue. 

> Check if everything is well tested and documented.
> Bump the version in Cargo.toml
> Run wasm-pack build --target web to generate the WASM binary
> Run wasm-pack publish to publish the package to npmjs.org

Not sure if we should bump up the version in Cargo.toml in this case, as the source code is still the same, it would just be built with a different target.

This PR aligns the build config with the intended usage of the playground so we don't run into those loading issues. More details on the differences can be checked out in [reference1](https://arc.net/l/quote/zyrwxkox) [reference2](https://rustwasm.github.io/wasm-bindgen/reference/deployment.html).
## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Update the contribution guide, and potentially retriger the publish process to fix the [issue](https://github.com/datafusion-contrib/datafusion-wasm-playground/issues/4) that datafusion-wasm-binding v0.3.1 cannot be loaded to [datafusion-wasm-playground](https://github.com/datafusion-contrib/datafusion-wasm-playground)

Users should be able to update datafusion-wasm-bindings package to v 0.3.1 the package is republished.

## Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, this change has been tested locally.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No
